### PR TITLE
Changed the way subscriptions are stored in mongo

### DIFF
--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -1268,24 +1268,6 @@ class UpLocRepAddrAfRm(ExtraBaseModel):
     fqdn: Optional[Fqdn] = None
 
 
-class UpLocRepAddrAfRm2(BaseModel):
-    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
-    ipv6Addrs: List[Ipv6Addr] = Field(..., min_items=1)
-    fqdn: Optional[Fqdn] = None
-
-
-class UpLocRepAddrAfRm3(BaseModel):
-    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
-    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
-    fqdn: Fqdn
-
-
-class UpLocRepAddrAfRm(BaseModel):
-    __root__: Optional[
-        Union[UpLocRepAddrAfRm1, UpLocRepAddrAfRm2, UpLocRepAddrAfRm3]
-    ] = Field(None, description="Represents the user plane addressing information.")
-
-
 class CodeWord(ExtraBaseModel):
     __root__: str = Field(..., description="Contains the codeword")
 

--- a/backend/app/app/tools/check_subscription.py
+++ b/backend/app/app/tools/check_subscription.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Optional
 from app.crud import crud_mongo
 
 
@@ -57,12 +58,12 @@ def check_expiration_time(expire_time):
         return False
 
 
-def check_numberOfReports(maximum_number_of_reports: int) -> bool:
-    if not maximum_number_of_reports:
+def check_numberOfReports(maximum_number_of_reports: Optional[int]) -> bool:
+    if maximum_number_of_reports is None:
         return True
 
-    if maximum_number_of_reports >= 1:
-        return True
+    if maximum_number_of_reports < 0:
+        logging.warning("Subscription has expired (maximum number of reports)")
+        return False
 
-    logging.warning("Subscription has expired (maximum number of reports")
-    return False
+    return True


### PR DESCRIPTION
This changes the way the notification is stored in the MongoDB. It changes the document to contain a reference to the SUPI and contain the subscription data as a field in the document. This is done since, as it has been pointed out, other identifiers such as MSISDN are not immutable and can chage, while the UE itself does not change. This means that, if for example a user were to swap phone number, the notifications would stop working. This fixes that problem.